### PR TITLE
touchesには現在のタップが全部入っていないのでマルチタップが上手く表示されない

### DIFF
--- a/KTouchPointerWindow/KTouchPointerWindow.m
+++ b/KTouchPointerWindow/KTouchPointerWindow.m
@@ -160,13 +160,13 @@ static char s_key;
 
 -(void) touchesBegan:(NSSet *)_touches withEvent:(UIEvent *)event
 {
-	self.touches = _touches;
+	self.touches = event.allTouches;
 	[self setNeedsDisplay];
 }
 
 -(void) touchesMoved:(NSSet *)_touches withEvent:(UIEvent *)event
 {
-	self.touches = _touches;
+	self.touches = event.allTouches;
 	[self setNeedsDisplay];	
 }
 
@@ -178,7 +178,9 @@ static char s_key;
 		}
 	}
 
-	self.touches = nil;
+	if (event.allTouches.count == 0) {
+		self.touches = nil;
+	}
 	[self setNeedsDisplay];
 }
 
@@ -190,7 +192,9 @@ static char s_key;
 		}
 	}
 	
-	self.touches = nil;
+	if (event.allTouches.count == 0) {
+		self.touches = nil;
+	}
 	[self setNeedsDisplay];
 }
 


### PR DESCRIPTION
どこかのアップデートで、_touchesには更新のあったタップのみが入るようになったようです。
そのため、マルチタップが正しく取れなくなっていました。
event.allTouchesに全て入っているので変えました。

また一本指を離すと全て表示が消えてしまうので、allTouchesが0の時だけリリースするようにしました。
